### PR TITLE
Add support for the report-uri directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ csp := csp.New(csp.StarterConfig())
 ... use of csp middleware ...
 ```
 
+### CSP violation reports
+
+Some browsers support sending CSP violation reports to a uri. You can specify
+this in the config with `ReportUri`.
+
+csp := csp.New(csp.Config{
+	Default:   csp.None,
+	Script:    csp.Self,
+	Connect:   csp.Self,
+	Img:       csp.Self,
+	ReportUri: "http://example.com/csp-violations",
+})
+
 ### Dynamic WebSocket Support
 
 If you specify WebSocket in the config, the middleware will dynamically

--- a/csp.go
+++ b/csp.go
@@ -17,6 +17,7 @@ const (
 	ConnectSrc = "connect-src"
 	ImgSrc     = "img-src"
 	StyleSrc   = "style-src"
+	ReportUri  = "report-uri"
 )
 
 // Config is Content Security Policy Configuration. If you do not define a
@@ -28,6 +29,7 @@ type Config struct {
 	Connect   string // connect-src CSP policy
 	Img       string // img-src CSP policy
 	Style     string // style-src CSP policy
+	ReportUri string // report-uri CSP violation reports URI
 }
 
 // StarterConfig is a reasonable default set of policies.
@@ -85,7 +87,7 @@ func (csp *CSP) HandlerFunc() http.HandlerFunc {
 // handlerFunc is the http.HandlerFunc interface
 func (csp *CSP) handlerFunc() http.HandlerFunc {
 	// Do as much work during construction as possible
-	var defaultPolicy, scriptPolicy, connectPolicy, imgPolicy, stylePolicy, baseConnectPolicy string
+	var defaultPolicy, scriptPolicy, connectPolicy, imgPolicy, stylePolicy, reportPolicy, baseConnectPolicy string
 	if csp.Default != "" {
 		defaultPolicy = fmt.Sprintf("%s %s;", DefaultSrc, csp.Default)
 	}
@@ -101,11 +103,14 @@ func (csp *CSP) handlerFunc() http.HandlerFunc {
 	if csp.Style != "" {
 		stylePolicy = fmt.Sprintf(" %s %s;", StyleSrc, csp.Style)
 	}
+	if csp.ReportUri != "" {
+		reportPolicy = fmt.Sprintf(" %s %s;", ReportUri, csp.ReportUri)
+	}
 	if csp.WebSocket && len(csp.Connect) == 0 {
 		baseConnectPolicy = " " + ConnectSrc
 	}
 	preConnectPolicy := defaultPolicy + scriptPolicy
-	postConnectPolicy := imgPolicy + stylePolicy
+	postConnectPolicy := imgPolicy + stylePolicy + reportPolicy
 	return func(rw http.ResponseWriter, r *http.Request) {
 		connectPolicy = baseConnectPolicy
 		if csp.WebSocket {

--- a/csp_test.go
+++ b/csp_test.go
@@ -364,3 +364,20 @@ func TestPartialConfig(t *testing.T) {
 		t.Errorf("Expected Policy %q, got %q", expected, policy)
 	}
 }
+
+func TestHandlerReportUri(t *testing.T) {
+	reportUri := "https://example.com/csp-reports"
+	csp := New(Config{
+		ReportUri: reportUri,
+	})
+	fn := csp.HandlerFunc()
+
+	rw := httptest.NewRecorder()
+	r := &http.Request{}
+	fn(rw, r)
+	header := rw.Header().Get(CSPHeader)
+	if header != fmt.Sprintf(" report-uri %s;", reportUri) {
+		t.Log(header)
+		t.Errorf("expected report-uri to be %q", reportUri)
+	}
+}


### PR DESCRIPTION
For reference:
  https://developers.google.com/web/fundamentals/security/csp/reporting?hl=en
  https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_CSP_violation_reports
